### PR TITLE
Fix `Warning: got packets out of order`

### DIFF
--- a/src/pages/api/v1/bylocation.js
+++ b/src/pages/api/v1/bylocation.js
@@ -62,7 +62,7 @@ export default async function (req, res) {
     const [data] = await connection.execute(query);
 
     // Close connection to the database
-    connection.destroy();
+    await connection.end();
 
     // Respond with appropriate status code and json
     res.status(STATUS_OK).json({content: data});

--- a/src/pages/api/v1/index.js
+++ b/src/pages/api/v1/index.js
@@ -34,7 +34,7 @@ export default async function handler(req, res) {
         // Creates and executes the query and then closes the connection
         const query = mysql.format('SELECT * FROM Data;');
         const [data] = await connection.execute(query);
-        connection.destroy();
+        await connection.end();
     
         let unit = req.query.tempunit || 'K';   // fallback to `Kelvin` if not specified
         if(unit.toUpperCase() !== 'K'){

--- a/src/pages/api/v1/ph.js
+++ b/src/pages/api/v1/ph.js
@@ -29,7 +29,7 @@ export default async function handler(req, res) {
         // Creates and executes the query and then closes the connection
         const query = mysql.format('SELECT pH, date FROM Data WHERE pH IS NOT NULL;');
         const [data] = await connection.execute(query);
-        connection.destroy();
+        await connection.end();
 
         // Returning the data
         res.status(STATUS_OK).json({content: data});

--- a/src/pages/api/v1/temperature.js
+++ b/src/pages/api/v1/temperature.js
@@ -41,7 +41,7 @@ export default async function handler(req, res){
         const [data] = await connection.execute(query);
 
         //Disconnecting from the database
-        connection.destroy();
+        await connection.end();
 
         let unit = req.query.unit || 'K';   // fallback to `Kelvin` if not specified
         if(unit.toUpperCase() !== 'K'){

--- a/src/pages/api/v1/upload.ts
+++ b/src/pages/api/v1/upload.ts
@@ -126,7 +126,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
         }
 
         // Close connection to the database
-        connection.destroy();
+        await connection.end();
 
         // Respond with the inserted data
         res.status(STATUS_CREATED)


### PR DESCRIPTION
Changed the disconnection method from `connection.destroy()` to `await connection.end()` for all endpoints which were using it