### PR TITLE
Use Docker Compose to build local app image

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,30 +30,18 @@ If you want to build the application image yourself, you can
 $ git clone https://github.com/sensor-network/open-data-portal.git
 $ cd open-data-portal
 ```
-2. Build the image: 
+2. Build a local image: 
 ```bash
-$ docker build -t open-data-portal .
+$ docker compose build app 
 ```
 
 #### Run
 You can now run the application using Docker Compose.
+If you build the image locally, it will use the local image. Otherwise, it will pull the latest version from the registry.
 
-If you build the image locally:
-1. In `docker-compose.yml`, change `image` to use your locally built image.
-```yml
-# ...
-app:
-  image: open-data-portal
-# ...
-```
-2. Then, depending on your version of docker/docker compose:
 ```bash
 $ docker compose up
-# or,
-$ docker-compose up
 ```
-
-If you didn't build the image you can use the publicly available image from `ghcr`, in which case you can skip step 1 above.
 
 The application will then start at `localhost:3000`
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,8 @@ services:
 
   # Open Data Portal Web Application with API, built using `./Dockerfile`
   app:
+    build:
+      context: .
     image: ghcr.io/sensor-network/open-data-portal-app:main
     ports:
       - "3000:3000"


### PR DESCRIPTION
This PR replaces the `docker build -t open-data-portal .` command with `docker compose build app` which creates a local image with the same name as the remote image (`ghcr.io/sensor-network/open-data-portal-app`). 

This way, changing the `docker-compose.yml` file is not necessary to run a locally build image.

I also removed the reference to the old `docker-compose` command since `docker compose` is now the standard.