### PR TITLE
Upload iso timestamp

### DIFF
--- a/.github/workflows/dev-integrate.yml
+++ b/.github/workflows/dev-integrate.yml
@@ -25,7 +25,7 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
       - name: Start up the test database
-        run: docker compose -f test-db.yml up
+        run: docker compose -f test-db.yml up -d
 
       - uses: actions/setup-node@v1
         with:

--- a/.github/workflows/dev-integrate.yml
+++ b/.github/workflows/dev-integrate.yml
@@ -25,7 +25,7 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
       - name: Start up the test database
-        run: docker compose -f test-db.yml up -d
+        run: docker compose -f test-db.yml up
 
       - uses: actions/setup-node@v1
         with:

--- a/__tests__/lib/conversions/convertTimestamp.test.js
+++ b/__tests__/lib/conversions/convertTimestamp.test.js
@@ -1,32 +1,27 @@
-import {timestampToUTC} from "../../../src/lib/conversions/convertTimestamp";
+import { ISOStringToSQLTimestamp as toSQL } from "../../../src/lib/conversions/convertTimestamp";
 
-// Format: YYYY-MM-DDTHH:mm:ss
-const test_cases1 = [
-    {input_timestamp: "2022-01-01:12:34:56", offset: 0, expected_output: "2022-01-01 12:34:56"},
-    {input_timestamp: "2022-01-01:12:34:56", offset: 1, expected_output: "2022-01-01 11:34:56"},
-    {input_timestamp: "2022-01-01:12:34:56", offset: -1, expected_output: "2022-01-01 13:34:56"},
-    {input_timestamp: "2022-01-01:00:00:00", offset: 1, expected_output: "2021-12-31 23:00:00"},
-
-];
-
-// Format: YYYY-MM-DDTHH:mm:ss.xxxZ
-const test_cases2 = [
-    {input_timestamp: "2022-01-01T12:34:56.000Z", offset: 0, expected_output: "2022-01-01 12:34:56"}
-]
-
-
-describe("Timestamps can be converted to UTC time given a timestamp and an offset", () => {
-    test("Timestamps on format 'YYYY-MM-DD:HH:mm:ss' can be converted", () => {
-        for (const test_case of test_cases1) {
-            const output = timestampToUTC(test_case.input_timestamp, test_case.offset);
-            expect(output).toEqual(test_case.expected_output);
-        }
-    });
-    
-    /*test("Timestamps on format 'YYYY-MM-DDTHH:mm:ss.xxxZ' can be converted", () => {
-        for (const test_case of test_cases2) {
-            const output = timestampToUTC(test_case.input_timestamp, test_case.offset);
-            expect(output).toEqual(test_case.expected_output);
-        }
-    });*/
+it("should accept full ISO8601 format", () => {
+    expect(toSQL('2022-01-01T12:00:00.000Z')).toEqual('2022-01-01T12:00:00.000');
+    expect(toSQL('2022-01-01T12:00:00.000+5')).toEqual('2022-01-01T07:00:00.000');
+    expect(toSQL('2022-01-01T12:00:00.000-5')).toEqual('2022-01-01T17:00:00.000');
 });
+
+it("should accept variations of it", () => {
+    expect(toSQL('2022-01-01T12:00:00Z')).toEqual('2022-01-01T12:00:00.000');
+    expect(toSQL('2022-01-01T12:00:00+3')).toEqual('2022-01-01T09:00:00.000');
+    expect(toSQL('2022-01-01T12:00:00-3')).toEqual('2022-01-01T15:00:00.000');
+
+    expect(toSQL('2022-01-01 12:00:00.000-5')).toEqual('2022-01-01T17:00:00.000');
+    expect(toSQL('2022-01-01:12:00:00.000-5')).toEqual('2022-01-01T17:00:00.000');
+    expect(toSQL('2022-01-01:12:00:00.000-05')).toEqual('2022-01-01T17:00:00.000');
+    expect(toSQL('2022-01-01 12:00:00.000-0500')).toEqual('2022-01-01T17:00:00.000');
+
+});
+
+it("should give good error messages if input is invalid", () => {
+    expect(() => toSQL('2022-01-01T12-00:00+3')).toThrow();
+    expect(() => toSQL('2022-01-01T30:00:00+3')).toThrow();
+    expect(() => toSQL('2022-01-40T12:00:00+3')).toThrow();
+    expect(() => toSQL('2022-13-01T12:00:00+3')).toThrow();
+
+})

--- a/__tests__/pages/api/v1/index.test.js
+++ b/__tests__/pages/api/v1/index.test.js
@@ -11,7 +11,7 @@ import {
 import { UNITS as TEMP_UNITS } from 'src/lib/units/temperature';
 import { UNITS as COND_UNITS } from 'src/lib/units/conductivity';
 
-describe.skip('/ API Endpoint', () => {
+describe('/ API Endpoint', () => {
     console.log = jest.fn();    // silence the console logs during tests
     function mockReqRes (method = 'GET') {
         return createMocks({

--- a/__tests__/pages/api/v1/index.test.js
+++ b/__tests__/pages/api/v1/index.test.js
@@ -11,7 +11,7 @@ import {
 import { UNITS as TEMP_UNITS } from 'src/lib/units/temperature';
 import { UNITS as COND_UNITS } from 'src/lib/units/conductivity';
 
-describe('/ API Endpoint', () => {
+describe.skip('/ API Endpoint', () => {
     console.log = jest.fn();    // silence the console logs during tests
     function mockReqRes (method = 'GET') {
         return createMocks({

--- a/db/init/init.sql
+++ b/db/init/init.sql
@@ -10,4 +10,4 @@ CREATE TABLE `Data` (
   CONSTRAINT `Data_chk_1` CHECK ((`pH` between 0 and 14))
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
 
-SET time_zone='00:00';
+SET time_zone='+00:00';

--- a/db/init/init.sql
+++ b/db/init/init.sql
@@ -3,9 +3,11 @@ CREATE TABLE `Data` (
   `pH` float DEFAULT NULL,
   `temperature` float DEFAULT NULL,
   `conductivity` float DEFAULT NULL,
-  `date` datetime DEFAULT NULL,
+  `date` timestamp DEFAULT NULL,
   `position` point NOT NULL /*!80003 SRID 4326 */,
   PRIMARY KEY (`id`),
   SPATIAL KEY `position` (`position`),
   CONSTRAINT `Data_chk_1` CHECK ((`pH` between 0 and 14))
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+SET time_zone='00:00';

--- a/public/swaggerConfig.json
+++ b/public/swaggerConfig.json
@@ -35,7 +35,7 @@
           }
         ],
         "requestBody": {
-          "description": "Posting data to the API in order to upload it to the database requires the JSON body to follow the following schema. You can insert multiple measurements at once by providing an array of `Measurement`-objects. Note that all objects has to be a valid `Measurement` for the request to be successful. Temperature can be supplied as `K`- kelvin, `C`- celsius and `F` - fahrenheit. Conductivity can be supplied as variations of `Spm`- Siemens per metre, `mhopm`- mho per metre, `ppm`- parts per million.",
+          "description": "Posting data to the API in order to upload it to the database requires the JSON body to follow the following schema. You can insert multiple measurements at once by providing an array of `Measurement`-objects. Note that all objects has to be a valid `Measurement` for the request to be successful. Temperature can be supplied as `K`- kelvin, `C`- celsius and `F` - fahrenheit. Conductivity can be supplied as variations of `Spm`- Siemens per metre, `mhopm`- mho per metre, `ppm`- parts per million. `timestamp` should be provided using ISO8601 format.",
           "content": {
             "application/json": {
               "schema": {
@@ -670,13 +670,7 @@
         "properties": {
           "timestamp": {
             "type": "string",
-            "format": "date-time",
-            "example": "2022-02-12 15:12:34"
-          },
-          "UTC_offset": {
-            "type": "number",
-            "format": "integer",
-            "example": 2
+            "format": "date-time"
           },
           "latitude": {
             "type": "number",
@@ -692,7 +686,7 @@
             "$ref": "#/components/schemas/Sensors"
           }
         },
-        "description": "The given contract to upload data to the database."
+        "description": "The given contract to upload data to the database. `timestamp` should be provided using ISO8601 format, e.g., YYYY-MM-DDTHH:mm:ssZ."
       },
       "Sensors": {
         "minProperties": 1,
@@ -735,8 +729,7 @@
         "properties": {
           "timestamp": {
             "type": "string",
-            "format": "date-time",
-            "example": "2022-02-22 13:12:34"
+            "format": "date-time"
           },
           "latitude": {
             "type": "number",


### PR DESCRIPTION
Update `/upload` to allow `timestamp` to use ISO8601 format, removing the need to supply a `UTC_offset`. Timestamps can now be provided in a number of different formats, including (but not exclusively):

* 2022-01-01T00:00:00.000Z
* 2022-01-01:00:00:00+1
* 2022-01-01 00:00:00+01
* 2022-01-01 00:00:00+0
* 2022-01-01Z
* ...
