### PR TITLE
Change Docker image tag to latest instead of main

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Log in to the Container registry
-        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        uses: docker/login-action@v1
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -29,14 +29,14 @@ jobs:
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        uses: docker/metadata-action@v3
         with:
           images: ${{ env.REGISTRY }}/${{ env.APP_IMAGE_NAME }}
 
       - name: Build and push Docker image (app)
-        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        uses: docker/build-push-action@v2
         with:
           context: .
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
+          tags: ${{ env.REGISTRY }}/${{ env.APP_IMAGE_NAME  }}:latest
           labels: ${{ steps.meta.outputs.labels }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
   app:
     build:
       context: .
-    image: ghcr.io/sensor-network/open-data-portal-app:main
+    image: ghcr.io/sensor-network/open-data-portal-app:latest
     ports:
       - "3000:3000"
     environment:


### PR DESCRIPTION
Change Docker image tag to `latest` instead of `main` since it is a widely used convention.
Also, change GitHub actions versions to a major version instead of a specific commit.

The possibility of having multiple parallel Docker image builds from different branches is not required.

