### PR TITLE
Fix style issues in ServerPaginationGrid

### DIFF
--- a/src/components/ServerPaginationGrid.jsx
+++ b/src/components/ServerPaginationGrid.jsx
@@ -21,6 +21,7 @@ import { useMeasurements } from "../lib/hooks/swr-extensions";
 import { PreferenceContext } from "../pages/_app";
 import { urlWithParams, capitalize, round } from "../lib/utilityFunctions";
 import { formatISO } from "date-fns";
+import { CardContent, Stack } from "@mui/material";
 
 const ENDPOINT = "/api/v3/measurements?";
 
@@ -124,7 +125,9 @@ const ServerPaginationGrid = () => {
     };
 
     return (
-      <div
+      <Stack
+        direction="row"
+        spacing={2}
         style={{
           width: "100%",
           right: 0,
@@ -139,27 +142,26 @@ const ServerPaginationGrid = () => {
             count={pageCount}
             page={page + 1}
             onChange={(event, value) => apiRef.current.setPage(value - 1)}
-          />
+            />
           <TextField
             size="small"
             label="Page"
             value={textFieldValue}
             onChange={(e) => setTextFieldValue(e.target.value)}
-          />
+            />
           <Button variant="contained" color="primary" onClick={validateInput}>
             Go To
           </Button>
         </ThemeProvider>
-      </div>
+      </Stack>
     );
   };
 
   return (
     <Card
       title="Explore the data on your own"
-      styles={{ margin: "40px 0 0 0" }}
     >
-      <div style={{ height: 750, margin: "20px 0" }}>
+      <CardContent style={{ height: 750 }}>
         {isLoading ? (
           <CustomProgressBar />
         ) : error ? (
@@ -185,7 +187,7 @@ const ServerPaginationGrid = () => {
             onPageSizeChange={(pageSize) => setPageSize(pageSize)}
           />
         )}
-      </div>
+      </CardContent>
 
       <div>
         <DateRangeSelector

--- a/src/pages/data.js
+++ b/src/pages/data.js
@@ -13,6 +13,7 @@ export default function App() {
         flexDirection: "column",
         gap: 50,
         marginBottom: 50,
+        marginTop: 50,
       }}
       maxWidth={"xl"}
     >


### PR DESCRIPTION
I removed margin settings from the ServerPaginationGrid card. 
The card shouldn't be responsible to set the margin or padding. It is the responsability of the higher-level container (data.js) to set consistent margins for all components included. 

I also use `CardContent` instead of the `div` with the style settings `margin: "20px 0"`. Such style settings get inconsitent very fast. It is recommended to use the intended compontents (`<Card><CardComponent>content</CardComponent></Card>`) to ensure a consistent layout through the whole application.


For the pagination component I replaced `div` with `Stack ` to have proper spacing between the button and the other UI elements.
![image](https://user-images.githubusercontent.com/9566732/165976929-b29a003e-3dbb-4fcb-9262-22348ec58a9a.png)
