### PR TITLE
95 history aggregates data incorrectly

### DIFF
--- a/__tests__/lib/utils/math/get-average.test.ts
+++ b/__tests__/lib/utils/math/get-average.test.ts
@@ -1,0 +1,25 @@
+import { getAverage } from "~/lib/utils/math";
+
+it("should get the average when all values are numbers", () => {
+  const values = [1, 2, 3];
+  const avg = getAverage(values);
+  expect(avg).toBe(2);
+});
+
+it("should get the average if there are nulled values", () => {
+  const values = [1, null, 3];
+  const avg = getAverage(values);
+  expect(avg).toBe(2);
+});
+
+it("should return null if there are no numbers", () => {
+  const values = [null, null, null];
+  const avg = getAverage(values);
+  expect(avg).toBeNull();
+});
+
+it("should return null if the array is empty", () => {
+  const values: (number | null)[] = [];
+  const avg = getAverage(values);
+  expect(avg).toBeNull();
+});

--- a/__tests__/lib/utils/math/get-average.test.ts
+++ b/__tests__/lib/utils/math/get-average.test.ts
@@ -12,8 +12,20 @@ it("should get the average if there are nulled values", () => {
   expect(avg).toBe(2);
 });
 
+it("should get the average if there are undefined values", () => {
+  const values = [undefined, 1, 3];
+  const avg = getAverage(values);
+  expect(avg).toBe(2);
+});
+
+it("should get the average if there are undefined and nulled values", () => {
+  const values = [undefined, null, 3, 2];
+  const avg = getAverage(values);
+  expect(avg).toBe(2.5);
+});
+
 it("should return null if there are no numbers", () => {
-  const values = [null, null, null];
+  const values = [null, undefined, null];
   const avg = getAverage(values);
   expect(avg).toBeNull();
 });

--- a/__tests__/lib/utils/math/get-max.test.ts
+++ b/__tests__/lib/utils/math/get-max.test.ts
@@ -12,8 +12,20 @@ it("should get the maximum if there are nulled values", () => {
   expect(max).toBe(3);
 });
 
+it("should get the maximum if there are undefined values", () => {
+  const values = [1, undefined, 3];
+  const max = getMax(values);
+  expect(max).toBe(3);
+});
+
+it("should get the maximum if there are undefined and nulled values", () => {
+  const values = [1, undefined, null, 3];
+  const max = getMax(values);
+  expect(max).toBe(3);
+});
+
 it("should return null if there are no numbers", () => {
-  const values = [null, null, null];
+  const values = [null, undefined, null];
   const max = getMax(values);
   expect(max).toBeNull();
 });

--- a/__tests__/lib/utils/math/get-max.test.ts
+++ b/__tests__/lib/utils/math/get-max.test.ts
@@ -1,0 +1,25 @@
+import { getMax } from "~/lib/utils/math";
+
+it("should get the maximum when all values are numbers", () => {
+  const values = [1, 2, 3];
+  const max = getMax(values);
+  expect(max).toBe(3);
+});
+
+it("should get the maximum if there are nulled values", () => {
+  const values = [1, null, 3];
+  const max = getMax(values);
+  expect(max).toBe(3);
+});
+
+it("should return null if there are no numbers", () => {
+  const values = [null, null, null];
+  const max = getMax(values);
+  expect(max).toBeNull();
+});
+
+it("should return null if the array is empty", () => {
+  const values: (number | null)[] = [];
+  const max = getMax(values);
+  expect(max).toBeNull();
+});

--- a/__tests__/lib/utils/math/get-min.test.ts
+++ b/__tests__/lib/utils/math/get-min.test.ts
@@ -1,0 +1,25 @@
+import { getMin } from "~/lib/utils/math";
+
+it("should get the minimum when all values are numbers", () => {
+  const values = [1, 2, 3];
+  const min = getMin(values);
+  expect(min).toBe(1);
+});
+
+it("should get the minimum if there are nulled values", () => {
+  const values = [1, null, 3];
+  const min = getMin(values);
+  expect(min).toBe(1);
+});
+
+it("should return null if there are no numbers", () => {
+  const values = [null, null, null];
+  const min = getMin(values);
+  expect(min).toBeNull();
+});
+
+it("should return null if the array is empty", () => {
+  const values: (number | null)[] = [];
+  const min = getMin(values);
+  expect(min).toBeNull();
+});

--- a/__tests__/lib/utils/math/get-min.test.ts
+++ b/__tests__/lib/utils/math/get-min.test.ts
@@ -12,6 +12,18 @@ it("should get the minimum if there are nulled values", () => {
   expect(min).toBe(1);
 });
 
+it("should get the minimum if there are undefined values", () => {
+  const values = [1, undefined, 3];
+  const min = getMin(values);
+  expect(min).toBe(1);
+});
+
+it("should get the minimum if there are undefined and nulled values", () => {
+  const values = [1, undefined, null, 3];
+  const min = getMin(values);
+  expect(min).toBe(1);
+});
+
 it("should return null if there are no numbers", () => {
   const values = [null, null, null];
   const min = getMin(values);

--- a/src/lib/database/history.ts
+++ b/src/lib/database/history.ts
@@ -4,9 +4,9 @@ import mysql, { RowDataPacket, OkPacket } from "mysql2/promise";
 export type CombinedFormat = {
   type: string;
   time: Date;
-  min: number;
-  avg: number;
-  max: number;
+  min: number | null;
+  avg: number | null;
+  max: number | null;
 };
 
 export const createOne = async ({

--- a/src/lib/utils/math/get-average.ts
+++ b/src/lib/utils/math/get-average.ts
@@ -1,12 +1,15 @@
 /* calculate average from an array of values that may contain null */
-export const getAverage = (values: number[]) => {
+export const getAverage = (values: (number | null)[]) => {
   let [sum, validValues] = [0, 0];
-  for (let i = 0; i < values.length; i++) {
-    const value = Number(values[i]);
-    if (!isNaN(value)) {
+  for (const value of values) {
+    if (value !== null) {
       sum += value;
       validValues++;
     }
+  }
+  /** return null if there were no numbers in the array */
+  if (validValues === 0) {
+    return null;
   }
   return sum / validValues;
 };

--- a/src/lib/utils/math/get-average.ts
+++ b/src/lib/utils/math/get-average.ts
@@ -1,8 +1,9 @@
 /* calculate average from an array of values that may contain null */
-export const getAverage = (values: (number | null)[]) => {
+export const getAverage = (values: (number | null | undefined)[]) => {
+  //console.log(values);
   let [sum, validValues] = [0, 0];
   for (const value of values) {
-    if (value !== null) {
+    if (value !== null && value !== undefined) {
       sum += value;
       validValues++;
     }

--- a/src/lib/utils/math/get-max.ts
+++ b/src/lib/utils/math/get-max.ts
@@ -1,8 +1,8 @@
 /* get the maximum from an array of values that may contain null */
-export const getMax = (values: (number | null)[]) => {
+export const getMax = (values: (number | null | undefined)[]) => {
   let max = Number.MIN_SAFE_INTEGER;
   for (const value of values) {
-    if (value !== null && value > max) {
+    if (value !== null && value !== undefined && value > max) {
       max = value;
     }
   }

--- a/src/lib/utils/math/get-max.ts
+++ b/src/lib/utils/math/get-max.ts
@@ -1,11 +1,14 @@
 /* get the maximum from an array of values that may contain null */
-export const getMax = (values: number[]) => {
+export const getMax = (values: (number | null)[]) => {
   let max = Number.MIN_SAFE_INTEGER;
-  for (let i = 0; i < values.length; i++) {
-    const value = Number(values[i]);
-    if (!isNaN(value) && value > max) {
+  for (const value of values) {
+    if (value !== null && value > max) {
       max = value;
     }
+  }
+  /** return null if there were no numbers in the array */
+  if (max === Number.MIN_SAFE_INTEGER) {
+    return null;
   }
   return max;
 };

--- a/src/lib/utils/math/get-min.ts
+++ b/src/lib/utils/math/get-min.ts
@@ -1,8 +1,8 @@
 /* get the minimum from an array of values that may contain null */
-export const getMin = (values: (number | null)[]) => {
+export const getMin = (values: (number | null | undefined)[]) => {
   let min = Number.MAX_SAFE_INTEGER;
   for (const value of values) {
-    if (value !== null && value < min) {
+    if (value !== null && value !== undefined && value < min) {
       min = value;
     }
   }

--- a/src/lib/utils/math/get-min.ts
+++ b/src/lib/utils/math/get-min.ts
@@ -1,11 +1,15 @@
 /* get the minimum from an array of values that may contain null */
-export const getMin = (values: number[]) => {
+export const getMin = (values: (number | null)[]) => {
   let min = Number.MAX_SAFE_INTEGER;
-  for (let i = 0; i < values.length; i++) {
-    const value = Number(values[i]);
-    if (!isNaN(value) && value < min) {
+  for (const value of values) {
+    if (value !== null && value < min) {
       min = value;
     }
   }
+  /** return null if there were no numbers in the array */
+  if (min === Number.MAX_SAFE_INTEGER) {
+    return null;
+  }
+  /** else return minimum */
   return min;
 };


### PR DESCRIPTION
In JS, casting `null` to `number` causes some unexpected behavior
this caused some issues where null values were accounted for in places where they shouldn't have. 
```js
// wrong
const value = null;
const asNumber = Number(value);  // 0
if (!isNaN(asNumber)) {
  // null values pass through this check
}

// correct
const value = null;
if (value !== null) {
  // only number in here
}
```