### PR TITLE
Validate station on post

### DIFF
--- a/src/lib/swagger-configs/v3.json
+++ b/src/lib/swagger-configs/v3.json
@@ -7,8 +7,12 @@
   },
   "servers": [
     {
+      "url": "https://sensornetwork.diptsrv003.bth.se/api/v3",
+      "description": "Production Server with HTTPS"
+    },
+    {
       "url": "http://sensornetwork.diptsrv003.bth.se/api/v3",
-      "description": "Production Server"
+      "description": "Production Server with HTTP"
     },
     {
       "url": "http://localhost:3000/api/v3",

--- a/src/lib/validators/measurement.ts
+++ b/src/lib/validators/measurement.ts
@@ -1,6 +1,6 @@
 import { isValid, parseISO } from "date-fns";
 import { z } from "zod";
-import ISOStringToSQLTimestamp from "~/lib/utils/iso-to-sql-timestamp";
+import { zId } from "./id";
 
 export const zCreateMeasurement = z.object({
   time: z
@@ -25,6 +25,7 @@ export const zCreateMeasurement = z.object({
       .refine((num) => num <= 180, "should be less than or equal to 180")
       .or(z.number().gte(-180).lte(180)), // no need to transform if input is already a number (e.g. when coming from req. body)
   }),
+  stationId: z.number().positive().int(),
   sensors: z.array(
     z.object({
       id: z.number().positive(),


### PR DESCRIPTION
This PR implements the requested functionality that every request should be validated in terms of what station is sending it. Now, Every POST-request have to specify the stationId, and all the sensors used in the request has to be linked to that sensor in order for the request to be accepted.

Given
```js
stations = [
  { stationId: 1, sensorIds: [ 1, 2 ], locationId: 1 },
  { stationId: 2, sensorIds: [ 3, 4 ], locationId: 2 }
]
```
A valid request would now look like
```json
{
  "time": "2022-05-09T10:59:12",
  "stationId": 1,
  "position": {
    "lat": 10.23421341,
    "long": 25.345324214
  },
  "sensors": [
    {
      "id": 1,
      "value": 20,
      "unit": "c"
    },
    {
      "id": 2,
      "value": 25000,
      "unit": "ppm"
    }
  ]
}
```
whereas the same request but specifying sensorIds 3 and 4 would be invalid.